### PR TITLE
bwipeout after fern opened

### DIFF
--- a/plugin/fern_hijack.vim
+++ b/plugin/fern_hijack.vim
@@ -8,8 +8,9 @@ function! s:hijack_directory() abort
   if !isdirectory(path)
     return
   endif
-  silent bwipeout %
+  let dirbuf = bufnr()
   execute printf('Fern %s', fnameescape(path))
+  silent execute 'bwipeout' dirbuf
 endfunction
 
 function! s:suppress_netrw() abort


### PR DESCRIPTION
Fixed the following issue.
```
C:\work\vim\fern>cat test.vim
set nocompatible
set rtp+=C:\\work\\vim\\fern\\fern.vim,C:\\work\\vim\\fern\\fern-hijack.vim

C:\work\vim\fern>gvim -N -n -u test.vim -U NONE -c "new x | e . | echo winnr('$')"

Expected: 2
Actual: 1
```