### PR TITLE
Use built-in expand() without check when fern.vim is not loaded.

### DIFF
--- a/plugin/fern_hijack.vim
+++ b/plugin/fern_hijack.vim
@@ -3,12 +3,13 @@ if exists('g:loaded_fern_hijack') || ( !has('nvim') && v:version < 801 )
 endif
 let g:loaded_fern_hijack = 1
 
-function! s:hijack_directory(path) abort
-  if !isdirectory(a:path)
+function! s:hijack_directory() abort
+  let path = s:expand('%:p')
+  if !isdirectory(path)
     return
   endif
   let bufnr = bufnr()
-  execute printf('keepjumps keepalt Fern %s', fnameescape(a:path))
+  execute printf('keepjumps keepalt Fern %s', fnameescape(path))
   execute printf('silent! bwipeout %d', bufnr)
 endfunction
 
@@ -26,13 +27,8 @@ function! s:expand(expr) abort
   endtry
 endfunction
 
-function! s:initial_hijack() abort
-	call s:hijack_directory(expand('%:p'))
-	autocmd fern-hijack BufEnter * ++nested call s:hijack_directory(s:expand('%:p'))
-endfunction
-
 augroup fern-hijack
   autocmd!
   autocmd VimEnter * call s:suppress_netrw()
-  autocmd BufEnter * ++once ++nested call s:initial_hijack()
+  autocmd BufEnter * ++nested call s:hijack_directory()
 augroup END

--- a/plugin/fern_hijack.vim
+++ b/plugin/fern_hijack.vim
@@ -3,13 +3,12 @@ if exists('g:loaded_fern_hijack') || ( !has('nvim') && v:version < 801 )
 endif
 let g:loaded_fern_hijack = 1
 
-function! s:hijack_directory() abort
-  let path = s:expand('%:p')
-  if !isdirectory(path)
+function! s:hijack_directory(path) abort
+  if !isdirectory(a:path)
     return
   endif
   let bufnr = bufnr()
-  execute printf('keepjumps keepalt Fern %s', fnameescape(path))
+  execute printf('keepjumps keepalt Fern %s', fnameescape(a:path))
   execute printf('silent! bwipeout %d', bufnr)
 endfunction
 
@@ -27,8 +26,13 @@ function! s:expand(expr) abort
   endtry
 endfunction
 
+function! s:initial_hijack() abort
+	call s:hijack_directory(expand('%:p'))
+	autocmd fern-hijack BufEnter * ++nested call s:hijack_directory(s:expand('%:p'))
+endfunction
+
 augroup fern-hijack
   autocmd!
   autocmd VimEnter * call s:suppress_netrw()
-  autocmd BufEnter * ++nested call s:hijack_directory()
+  autocmd BufEnter * ++once ++nested call s:initial_hijack()
 augroup END

--- a/plugin/fern_hijack.vim
+++ b/plugin/fern_hijack.vim
@@ -21,10 +21,12 @@ endfunction
 
 function! s:expand(expr) abort
   try
-    return fern#util#expand(a:expr)
+    if exists('g:loaded_fern')
+      return fern#util#expand(a:expr)
+    endif
   catch /^Vim\%((\a\+)\)\=:E117:/
-    return expand(a:expr)
   endtry
+  return expand(a:expr)
 endfunction
 
 augroup fern-hijack

--- a/plugin/fern_hijack.vim
+++ b/plugin/fern_hijack.vim
@@ -19,6 +19,7 @@ function! s:suppress_netrw() abort
   endif
 endfunction
 
+" Called every BufEnter, but checks if fern#util#expand exists, thus preventing unnecessary load of fern.vim.
 function! s:expand(expr) abort
   if exists('fern#util#expand')
     return fern#util#expand(a:expr)

--- a/plugin/fern_hijack.vim
+++ b/plugin/fern_hijack.vim
@@ -20,12 +20,9 @@ function! s:suppress_netrw() abort
 endfunction
 
 function! s:expand(expr) abort
-  try
-    if exists('g:loaded_fern')
-      return fern#util#expand(a:expr)
-    endif
-  catch /^Vim\%((\a\+)\)\=:E117:/
-  endtry
+  if exists('fern#util#expand')
+    return fern#util#expand(a:expr)
+  endif
   return expand(a:expr)
 endfunction
 


### PR DESCRIPTION
Thank you for the wonderful plugin.

The current implementation uses `fern#util#expand` in `s:expand` even on the first `BufEnter`.
This causes it to load even on the first startup even if it is not necessary to load `fern.vim`, for example when opening a file (not a directory).

This PR changes `s:expand` to use the built-in `expand()` function without checking when `fern.vim` is not loaded.
This enables for lazy loading of `fern.vim`, which should improve startup speed.

Thanks.
